### PR TITLE
Deploy zipped software repository for offline use

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -22,6 +22,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; th
   git rm -rf repository
   mkdir -p repository 
   cp -rf ../com.codeaffine.gonsole.releng/repository/target/repository/* ./repository
+  zip -r repository/gonsole.zip repository/*
   
   # add, commit and push files
   git add -f .


### PR DESCRIPTION
Change the deployment script to place a zipped version of the repository alongside the regular repository files.